### PR TITLE
Clarify deleted records in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ class Video extends Model
 }
 ```
 
-Now you can delete an `App\Video` record, and any associated `App\Image`, `App\Tag` and
-`App\Options` records will be deleted.
+Now you can delete an `App\Video` record, and any associated `App\Image`, `App\Options` and pivot records for
+`App\Tag` will be deleted.
 
 ## Delete Residuals
 


### PR DESCRIPTION
The Morph To Many relation uses a pivot table. Thus, not the Tag record will be deleted, but the pivot record in the ```taggables``` table.